### PR TITLE
change logrus package name to lowercase

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/mgutz/ansi"
+	"github.com/sirupsen/logrus"
 )
 
 const reset = ansi.Reset


### PR DESCRIPTION
This errors occurred.

```
grouped write of manifest, lock and vendor: error while writing out vendor tree: error while exporting github.com/sirupsen/logrus: /var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/.gitignore already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/.travis.yml already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/CHANGELOG.md already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/LICENSE already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/README.md already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/alt_exit.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/alt_exit_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/doc.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/entry.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/entry_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/examples/basic/basic.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/examples/hook/hook.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/exported.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/formatter.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/formatter_bench_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hook_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/syslog/README.md already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/test/test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/test/test_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/json_formatter.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/json_formatter_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logger.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logger_bench_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logrus.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logrus_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_appengine.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_bsd.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_linux.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_notwindows.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_solaris.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_windows.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/text_formatter.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/text_formatter_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/writer.go already exists, no checkout
```

Packages conflict with uppercase and lowercase, because logrus changed packagename to lowercase.
https://github.com/sirupsen/logrus/issues/553

I want to update all vuls package's logrus package name to avoid this errors.
Target repositories are below.

1. kotakanbe/logrus-prefixed-formatter
1. kotakanbe/go-cve-dictionary
1. kotakanbe/goval-dictionary
1. future-architect/vuls